### PR TITLE
fix: add extra check for country

### DIFF
--- a/src/integrations/formie/TeamleaderFocus.php
+++ b/src/integrations/formie/TeamleaderFocus.php
@@ -870,7 +870,19 @@ class TeamleaderFocus extends Crm implements OAuthProviderInterface
             return null;
         }
 
-        $countries = Collection::make(Craft::$app->getAddresses()->getCountryList())->flip();
+        // Get the country list from Craft, with ISO code as key.
+        $countriesISOList = Collection::make(Craft::$app->getAddresses()->getCountryList());
+
+        // Check if length of fields['country'] is 2, use country code as is.
+        // Otherwise, use the country code from the standardized list.
+        $country = strlen($fields['country']) === 2 && $countriesISOList->get($fields['country']) ? $fields['country'] : $countriesISOList->flip()->get($fields['country']);
+
+        // If country is not found, return error.
+        if (!$country) {
+            Integration::error($this, Craft::t('formie', 'Missing country code {country}. Sent payload {payload}', [ 'country' => $fields['country'], 'payload' => Json::encode($fields) ]), true);
+
+            return null;
+        }
 
         return [
             'type' => 'primary',
@@ -878,7 +890,7 @@ class TeamleaderFocus extends Crm implements OAuthProviderInterface
                 'line_1' => $fields['addressLine1'],
                 'postal_code' => $fields['postal_code'],
                 'city' => $fields['city'],
-                'country' => $countries->get($fields['country']),
+                'country' => $country,
             ]
         ];
     }


### PR DESCRIPTION
This PR attempts to solve #8 by checking of the passed value for country is 2 letters (ISO standard) and is in the country list.

It also throws an error if the country code is invalid (not sure if this is needed or just not update the country though).