### PR TITLE
fix: tolerate legacy Formie integration settings removed in 5.2.2 (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Teamleader
 
+## 5.2.3 - unreleased
+### Fixed
+- Fixed `UnknownPropertyException` when loading a Formie integration saved on 5.2.1 or earlier. The `$companyId`, `$dealId`, and `$userId` properties removed in 5.2.2 are still present in stored integration settings, and Formie threw while rehydrating them — crashing the Formie integrations CP page and any front-end page that loads a form. These legacy keys are now silently discarded on hydration and removed from settings on the next save. ([#31](https://github.com/craftpulse/craft-teamleader-focus/issues/31))
+
 ## 5.2.2 - 2026-05-27
 ### Security
 - Removed public `$companyId`, `$dealId`, and `$userId` properties from the Formie integration class — these held per-submission state and could risk cross-submission data leakage if Formie hydrated an integration from a stored representation. IDs are now scoped to local variables in `sendPayload()` and passed as parameters to `_prepPayload()`. ([#14](https://github.com/craftpulse/craft-teamleader-focus/issues/14))

--- a/src/integrations/formie/TeamleaderFocus.php
+++ b/src/integrations/formie/TeamleaderFocus.php
@@ -174,6 +174,33 @@ class TeamleaderFocus extends Crm implements OAuthProviderInterface
     // =========================================================================
 
     /**
+     * Silently discard the transient per-submission properties (`userId`,
+     * `companyId`, `dealId`) that were removed in 5.2.2 for security reasons (#14).
+     *
+     * Formie persists an integration's public properties as its stored settings
+     * and rehydrates them through {@see \yii\base\BaseObject::__set()}. Settings
+     * saved by <= 5.2.1 still carry these keys, so hydrating them on 5.2.2+ throws
+     * UnknownPropertyException and crashes both the Formie integrations CP page and
+     * any front-end page that loads a form (#31). Dropping the keys here keeps
+     * hydration working without re-introducing the persisted state — the values are
+     * discarded and never written back, so settings self-heal on the next save.
+     *
+     * @param  string $name
+     * @param  mixed  $value
+     *
+     * @author CraftPulse
+     * @since  5.2.3
+     */
+    public function __set($name, $value): void
+    {
+        if (in_array($name, ['userId', 'companyId', 'dealId'], true)) {
+            return;
+        }
+
+        parent::__set($name, $value);
+    }
+
+    /**
      * @author CraftPulse
      */
     public function getIconUrl(): string


### PR DESCRIPTION
## Problem

After upgrading to 5.2.2, sites with a saved TeamleaderFocus Formie integration crash with:

```
yii\base\UnknownPropertyException: Setting unknown property:
craftpulse\teamleader\integrations\formie\TeamleaderFocus::companyId
```

This takes down the Formie → Settings → Integrations page (Formie loads all integrations there) and any front-end page that renders a Formie form / triggers integration loading.

## Root cause

The 5.2.2 security fix (#14) removed the public `$companyId`, `$dealId`, and `$userId` properties — correctly, as they held transient per-submission state.

But Formie persists an integration's public properties as its stored settings and rehydrates them through `yii\base\BaseObject::__set()`. Settings saved on 5.2.1 or earlier still carry those three keys, so on 5.2.2+ hydration hits a property that no longer exists and throws.

Confirmed: the properties existed through tag `5.2.1` and were removed in a commit that only landed in `5.2.2`.

## Fix

Override `__set()` to silently discard the three legacy keys, delegating everything else to `parent::__set()`:

- Fixes existing ≤5.2.1 installs immediately on upgrade — no migration needed.
- Doesn't reintroduce the #14 issue — values are dropped, never written back.
- Self-heals: once an integration is re-saved, the keys disappear from storage because the properties no longer exist.
- Scoped to the three known keys, so genuine config typos / future removals still surface as errors rather than being swallowed.

CHANGELOG entry added under `5.2.3 - unreleased`.

Closes #31