### PR TITLE
Release 5.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for Teamleader
 
-## 5.2.3 - 2026-05-27
+## 5.2.2 - 2026-05-27
 ### Security
 - Removed public `$companyId`, `$dealId`, and `$userId` properties from the Formie integration class — these held per-submission state and could risk cross-submission data leakage if Formie hydrated an integration from a stored representation. IDs are now scoped to local variables in `sendPayload()` and passed as parameters to `_prepPayload()`. ([#14](https://github.com/craftpulse/craft-teamleader-focus/issues/14))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Release Notes for Teamleader
 
-## 5.2.2 - unreleased
+## 5.2.3 - 2026-05-27
 ### Security
 - Removed public `$companyId`, `$dealId`, and `$userId` properties from the Formie integration class — these held per-submission state and could risk cross-submission data leakage if Formie hydrated an integration from a stored representation. IDs are now scoped to local variables in `sendPayload()` and passed as parameters to `_prepPayload()`. ([#14](https://github.com/craftpulse/craft-teamleader-focus/issues/14))
 
 ### Added
-- Added "Update custom fields partially" option for Contacts to partially update their custom fields ([#24](https://github.com/craftpulse/craft-teamleader-focus/issues/24)).
-- Added "Update custom fields partially" option for Companies to partially update their custom fields ([#24](https://github.com/craftpulse/craft-teamleader-focus/issues/24))
+- Added "Update custom fields partially" option for Contacts to partially update their custom fields. ([#24](https://github.com/craftpulse/craft-teamleader-focus/issues/24)) - Thanks [@ishetnogferre](https://github.com/ishetnogferre)
+- Added "Update custom fields partially" option for Companies to partially update their custom fields. ([#24](https://github.com/craftpulse/craft-teamleader-focus/issues/24)) - Thanks [@ishetnogferre](https://github.com/ishetnogferre)
 
 ### Fixed
 - Fixed `sendPayload()` and `fetchFormSettings()` catching only `yii\base\Exception`, letting `\RuntimeException`, GuzzleHttp network errors, and `IdentityProviderException` propagate uncaught. Catches now broaden to `\Exception|\Error` and route through Formie's normal error handling. ([#13](https://github.com/craftpulse/craft-teamleader-focus/issues/13))
@@ -15,6 +15,7 @@
 - Fixed companies error logs encoding `$contactValues` instead of `$companyValues`, making company-related API failures impossible to debug. ([#20](https://github.com/craftpulse/craft-teamleader-focus/issues/20))
 - Fixed `getCurrencyOptions()` making a live API call on every CP page render. Now cached for 24h on success only — API failures fall back to defaults without polluting the cache. ([#21](https://github.com/craftpulse/craft-teamleader-focus/issues/21))
 - Fixed `contacts.linkToCompany` failing with "already linked" when the contact is already attached to the company. Now checks `companies.info` related_contacts first and skips the link call when the contact is already present. ([#22](https://github.com/craftpulse/craft-teamleader-focus/issues/22)) - Thanks [@ishetnogferre](https://github.com/ishetnogferre)
+- Fixed `companies.info` `includes` parameter on the already-linked check being sent as a JSON array instead of the documented comma-separated string. Teamleader would not have returned the `related_contacts` sideload, silently re-introducing the "already linked" error from [#22](https://github.com/craftpulse/craft-teamleader-focus/issues/22). Now sent as a string.
 
 ### Changed
 - Removed `declare(strict_types=1)` from `TeamleaderFocusRefreshTokenGrant` per Craft CMS plugin conventions. ([#12](https://github.com/craftpulse/craft-teamleader-focus/issues/12))
@@ -22,8 +23,7 @@
 - Added `defineRules()` to the Formie integration: `dealTitle` is required when `mapToDeals` is enabled; `defaultCurrency` is validated as a 3-char string. Existing saved integrations with `mapToDeals=true` and an empty `dealTitle` will fail validation on next save in the CP. ([#21](https://github.com/craftpulse/craft-teamleader-focus/issues/21))
 - Loosened composer PHP constraint from `^8.2.0` to `^8.2`. ([#21](https://github.com/craftpulse/craft-teamleader-focus/issues/21))
 - Section headers, `@author` annotations, and PSR-12 formatting brought in line with Craft CMS plugin conventions across the codebase. ([#16](https://github.com/craftpulse/craft-teamleader-focus/issues/16), [#17](https://github.com/craftpulse/craft-teamleader-focus/issues/17), [#19](https://github.com/craftpulse/craft-teamleader-focus/issues/19))
-- New option "Update custom fields partially" for Contacts and Companies is `enabled` by default. (([#24](https://github.com/craftpulse/craft-teamleader-focus/issues/24)))
-
+- New option "Update custom fields partially" for Contacts and Companies is enabled by default. Existing integrations will switch from full-collection replacement to partial updates on next form submission after upgrade. ([#24](https://github.com/craftpulse/craft-teamleader-focus/issues/24))
 
 ## 5.2.1 - 2026-04-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Teamleader
 
+## 5.2.3 - unreleased
+### Fixed
+- Fixed `UnknownPropertyException` when loading a Formie integration saved on 5.2.1 or earlier. The `$companyId`, `$dealId`, and `$userId` properties removed in 5.2.2 are still present in stored integration settings, and Formie threw while rehydrating them — crashing the Formie integrations CP page and any front-end page that loads a form. These legacy keys are now silently discarded on hydration and removed from settings on the next save. ([#31](https://github.com/craftpulse/craft-teamleader-focus/issues/31))
+
 ## 5.2.2 - 2026-05-27
 ### Security
 - Removed public `$companyId`, `$dealId`, and `$userId` properties from the Formie integration class — these held per-submission state and could risk cross-submission data leakage if Formie hydrated an integration from a stored representation. IDs are now scoped to local variables in `sendPayload()` and passed as parameters to `_prepPayload()`. ([#14](https://github.com/craftpulse/craft-teamleader-focus/issues/14))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release Notes for Teamleader
 
-## 5.2.3 - unreleased
+## 5.2.3 - 2026-06-09
 ### Fixed
 - Fixed `UnknownPropertyException` when loading a Formie integration saved on 5.2.1 or earlier. The `$companyId`, `$dealId`, and `$userId` properties removed in 5.2.2 are still present in stored integration settings, and Formie threw while rehydrating them — crashing the Formie integrations CP page and any front-end page that loads a form. These legacy keys are now silently discarded on hydration and removed from settings on the next save. ([#31](https://github.com/craftpulse/craft-teamleader-focus/issues/31))
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "craftpulse/craft-teamleader-focus",
   "description": "Teamleader Focus plugin",
   "type": "craft-plugin",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "keywords": [
     "craft",
     "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "craftpulse/craft-teamleader-focus",
   "description": "Teamleader Focus plugin",
   "type": "craft-plugin",
-  "version": "5.2.3",
+  "version": "5.2.2",
   "keywords": [
     "craft",
     "cms",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "craftpulse/craft-teamleader-focus",
   "description": "Teamleader Focus plugin",
   "type": "craft-plugin",
-  "version": "5.2.1",
+  "version": "5.2.3",
   "keywords": [
     "craft",
     "cms",

--- a/src/integrations/formie/TeamleaderFocus.php
+++ b/src/integrations/formie/TeamleaderFocus.php
@@ -61,9 +61,9 @@ class TeamleaderFocus extends Crm implements OAuthProviderInterface
     private const CURRENCY_CACHE_TTL = 86400;
 
     /**
-     * @var string The update strategy for custom fields.
+     * Update strategy value sent to Teamleader to merge custom fields on updates
+     * instead of replacing the full collection.
      */
-
     public const CUSTOM_FIELDS_UPDATE_STRATEGY_PARTIAL = 'partial';
 
     // Public Properties
@@ -454,7 +454,7 @@ class TeamleaderFocus extends Crm implements OAuthProviderInterface
                 // Get company info with related contacts
                 $response = $this->deliverPayload($submission, 'companies.info', [
                     'id' => $companyId,
-                    'includes' => ['related_contacts'],
+                    'includes' => 'related_contacts',
                 ]);
 
                 // Check related_contacts items for the contact id on id

--- a/src/integrations/formie/TeamleaderFocus.php
+++ b/src/integrations/formie/TeamleaderFocus.php
@@ -174,6 +174,33 @@ class TeamleaderFocus extends Crm implements OAuthProviderInterface
     // =========================================================================
 
     /**
+     * Silently discard the transient per-submission properties (`userId`,
+     * `companyId`, `dealId`) that were removed in 5.2.2 for security reasons (#14).
+     *
+     * Formie persists an integration's public properties as its stored settings
+     * and rehydrates them through {@see \yii\base\BaseObject::__set()}. Settings
+     * saved by <= 5.2.1 still carry these keys, so hydrating them on 5.2.2+ throws
+     * UnknownPropertyException and crashes both the Formie integrations CP page and
+     * any front-end page that loads a form (#31). Dropping the keys here keeps
+     * hydration working without re-introducing the persisted state — the values are
+     * discarded and never written back, so settings self-heal on the next save.
+     *
+     * @param  string $name
+     * @param  mixed  $value
+     *
+     * @author CraftPulse
+     * @since  5.2.3
+     */
+    public function __set($name, $value): void
+    {
+        if (in_array($name, ['userId', 'companyId', 'dealId'], true)) {
+            return;
+        }
+
+        parent::__set($name, $value);
+    }
+
+    /**
      * @author CraftPulse
      */
     public function getIconUrl(): string


### PR DESCRIPTION
## 5.2.3 — 2026-06-09

### Fixed
- `UnknownPropertyException` when loading a Formie integration saved on 5.2.1 or earlier. The `$companyId`, `$dealId`, and `$userId` properties removed in 5.2.2 (#14) are still present in stored integration settings, and Formie threw while rehydrating them — crashing the Formie integrations CP page and any front-end page that loads a form. These legacy keys are now silently discarded on hydration and removed from settings on the next save. (#31)

Version bumped to 5.2.3, CHANGELOG dated.

Closes #31